### PR TITLE
feat: add support to pass a function as mapper value

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -54,6 +54,52 @@ test('rendering children component', () => {
   expect(result.html()).toBe('<div>foobar</div>')
 })
 
+test('should allow a function as mapper', () => {
+  const Foo = ({ children }) => children('foo')
+  const foo = jest.fn(() => <Foo />)
+  const children = jest.fn(() => null)
+  const Composed = adopt({ foo })
+
+  mount(<Composed>{children}</Composed>)
+
+  expect(foo).toHaveBeenCalled()
+  expect(children).toHaveBeenCalledWith({ foo: 'foo' })
+})
+
+test('should provide a function mapper with all previous render prop results', () => {
+  const Foo = ({ children }) => children('foo')
+  const Bar = ({ children }) => children('bar')
+  const bar = jest.fn(() => <Bar />)
+  const children = jest.fn(() => null)
+
+  interface RenderProps {
+    foo: 'foo'
+    bar: 'bar'
+  }
+
+  const Composed = adopt<RenderProps>({
+    foo: <Foo />,
+    bar,
+  })
+
+  mount(<Composed>{children}</Composed>)
+
+  expect(bar.mock.calls[0][0]).toHaveProperty('foo', 'foo')
+  expect(children).toHaveBeenCalledWith({ foo: 'foo', bar: 'bar' })
+})
+
+test('should provide mapper functions with Composed component props', () => {
+  const Foo = ({ children }) => children('foo')
+  const foo = jest.fn(() => <Foo />)
+  const children = jest.fn(() => null)
+  const Composed = adopt({ foo })
+
+  mount(<Composed bar='bar'>{children}</Composed>)
+
+  expect(foo).toHaveBeenCalledWith({ bar: 'bar' })
+  expect(children).toHaveBeenCalledWith({ foo: 'foo' })
+})
+
 test('throw with a wrong value on mapper', () => {
   expect(() => {
     const Composed = adopt({ foo: 'helo' })

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -56,7 +56,7 @@ test('rendering children component', () => {
 
 test('should allow a function as mapper', () => {
   const Foo = ({ children }) => children('foo')
-  const foo = jest.fn(() => <Foo />)
+  const foo = jest.fn(({ renderProp }) => <Foo children={ renderProp } />)
   const children = jest.fn(() => null)
   const Composed = adopt({ foo })
 
@@ -69,7 +69,7 @@ test('should allow a function as mapper', () => {
 test('should provide a function mapper with all previous render prop results', () => {
   const Foo = ({ children }) => children('foo')
   const Bar = ({ children }) => children('bar')
-  const bar = jest.fn(() => <Bar />)
+  const bar = jest.fn(({ renderProp }) => <Bar children={ renderProp } />)
   const children = jest.fn(() => null)
 
   interface RenderProps {
@@ -90,13 +90,13 @@ test('should provide a function mapper with all previous render prop results', (
 
 test('should provide mapper functions with Composed component props', () => {
   const Foo = ({ children }) => children('foo')
-  const foo = jest.fn(() => <Foo />)
+  const foo = jest.fn(({ renderProp }) => <Foo children={ renderProp } />)
   const children = jest.fn(() => null)
   const Composed = adopt({ foo })
 
   mount(<Composed bar="bar">{children}</Composed>)
 
-  expect(foo).toHaveBeenCalledWith({ bar: 'bar' })
+  expect(foo.mock.calls[0][0]).toHaveProperty('bar', 'bar')
   expect(children).toHaveBeenCalledWith({ foo: 'foo' })
 })
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -56,7 +56,7 @@ test('rendering children component', () => {
 
 test('should allow a function as mapper', () => {
   const Foo = ({ children }) => children('foo')
-  const foo = jest.fn(({ renderProp }) => <Foo children={ renderProp } />)
+  const foo = jest.fn(({ renderProp }) => <Foo children={renderProp} />)
   const children = jest.fn(() => null)
   const Composed = adopt({ foo })
 
@@ -69,7 +69,7 @@ test('should allow a function as mapper', () => {
 test('should provide a function mapper with all previous render prop results', () => {
   const Foo = ({ children }) => children('foo')
   const Bar = ({ children }) => children('bar')
-  const bar = jest.fn(({ renderProp }) => <Bar children={ renderProp } />)
+  const bar = jest.fn(({ renderProp }) => <Bar children={renderProp} />)
   const children = jest.fn(() => null)
 
   interface RenderProps {
@@ -90,7 +90,7 @@ test('should provide a function mapper with all previous render prop results', (
 
 test('should provide mapper functions with Composed component props', () => {
   const Foo = ({ children }) => children('foo')
-  const foo = jest.fn(({ renderProp }) => <Foo children={ renderProp } />)
+  const foo = jest.fn(({ renderProp }) => <Foo children={renderProp} />)
   const children = jest.fn(() => null)
   const Composed = adopt({ foo })
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -94,7 +94,7 @@ test('should provide mapper functions with Composed component props', () => {
   const children = jest.fn(() => null)
   const Composed = adopt({ foo })
 
-  mount(<Composed bar='bar'>{children}</Composed>)
+  mount(<Composed bar="bar">{children}</Composed>)
 
   expect(foo).toHaveBeenCalledWith({ bar: 'bar' })
   expect(children).toHaveBeenCalledWith({ foo: 'foo' })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,20 +26,15 @@ export function adopt<RP extends Record<string, any>>(
   return Object.keys(mapper).reduce(
     (Component: RPC<RP>, key: keyof RP): RPC<RP> => ({ children, ...rest }) => (
       <Component>
-        {props =>
-          React.cloneElement(
-            typeof mapper[key] === 'function'
-              ? mapper[key]({ ...rest, ...props })
-              : mapper[key],
-            {
-              children: (childProps: any) =>
-                children({
-                  ...props,
-                  [key]: childProps,
-                }),
-            }
+        {props => {
+          const renderProp = (childProps: any) => children(
+            Object.assign({}, props, { [key]: childProps })
           )
-        }
+
+          return typeof mapper[key] === 'function'
+            ? mapper[key](Object.assign({}, rest, props, { renderProp }))
+            : React.cloneElement(mapper[key], { children: renderProp })
+        }}
       </Component>
     ),
     Children

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react'
 import { ComponentType, ReactNode, ReactElement } from 'react'
 
-const isAllElementValid = (values: ReactNode[]): boolean =>
-  !values.some(value => !React.isValidElement(value))
-
 export type ChildrenFn<P> = (props: P) => ReactNode
 
 export type RPC<Props> = ComponentType<{
@@ -15,7 +12,7 @@ export type Mapper<R> = Record<keyof R, ReactElement<any> | any>
 export function adopt<RP extends Record<string, any>>(
   mapper: Mapper<RP>
 ): RPC<RP> {
-  if (!isAllElementValid(Object.values(mapper))) {
+  if (!Object.values(mapper).some(React.isValidElement)) {
     throw new Error(
       'The render props object mapper just accept valid elements as value'
     )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,17 +26,20 @@ export function adopt<RP extends Record<string, any>>(
   return Object.keys(mapper).reduce(
     (Component: RPC<RP>, key: keyof RP): RPC<RP> => ({ children, ...rest }) => (
       <Component>
-        {props => React.cloneElement(
-          typeof mapper[key] === 'function'
-            ? mapper[key]({ ...rest, ...props })
-            : mapper[key],
-          {
-            children: (childProps: any) => children({
-              ...props,
-              [key]: childProps
-            }),
-          }
-        )}
+        {props =>
+          React.cloneElement(
+            typeof mapper[key] === 'function'
+              ? mapper[key]({ ...rest, ...props })
+              : mapper[key],
+            {
+              children: (childProps: any) =>
+                children({
+                  ...props,
+                  [key]: childProps,
+                }),
+            }
+          )
+        }
       </Component>
     ),
     Children

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,9 +27,8 @@ export function adopt<RP extends Record<string, any>>(
     (Component: RPC<RP>, key: keyof RP): RPC<RP> => ({ children, ...rest }) => (
       <Component>
         {props => {
-          const renderProp = (childProps: any) => children(
-            Object.assign({}, props, { [key]: childProps })
-          )
+          const renderProp = (childProps: any) =>
+            children(Object.assign({}, props, { [key]: childProps }))
 
           return typeof mapper[key] === 'function'
             ? mapper[key](Object.assign({}, rest, props, { renderProp }))


### PR DESCRIPTION
Allow `adopt` to receive functions as mappers to allow cascating props and receiving the composition props.

i.e.:

```js
const Composed = adopt({
  foo: <Foo />,
  bar: ({ foo, tor, renderProp }) => <Bar children={ renderProp } />
})

<Composed tor='tor'>
  { ({ foo, bar }) => (
    <div>
      foo: {foo}
      bar: {bar}
    </div>
  ) }
</Composed>
```

*Ps.: This is backwards compatible with the currently working API*
*Ps.2: I need help making the build process work (not a TS user here)*