### PR TITLE
Don't recreate adopt instance in every render

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,9 +87,14 @@ export type AdoptProps<RP, P> = P & {
   children: ChildrenFn<RP>
 }
 
-export const Adopt: React.SFC<AdoptProps<any, any>> = props => {
-  const Composed = adopt(props.mapper)
-  const composedProps = omit(['children', 'mapper'], props)
+export class Adopt extends React.Component<AdoptProps<any, any>> {
+  constructor(props) {
+    super(props)
+    this.Composed = adopt(props.mapper)
+  }
 
-  return <Composed {...composedProps}>{props.children}</Composed>
+  render() {
+    const { mapper, ...props } = this.props
+    return <this.Composed {...props} />
+  }
 }


### PR DESCRIPTION
Fix #11 

This change create a `adopt()` instance at constructor, so it will never change. It's like creating it outside (it really does the same thing).