### PR TITLE
disable allowSyntheticDefaultImports, fixes #18

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import * as React from 'react'
 import { ReactNode, ReactElement } from 'react'
-import hoistNonReactStatic from 'hoist-non-react-statics'
+import * as hoistNonReactStatic from 'hoist-non-react-statics'
 import getDisplayName from 'react-display-name'
 
 const { values, keys, assign } = Object

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "inlineSourceMap": true,
-    "allowSyntheticDefaultImports": true,
 
     "jsx": "react",
     "strict": true /* Enable all strict type-checking options. */,

--- a/utils/test-setup.ts
+++ b/utils/test-setup.ts
@@ -1,4 +1,4 @@
 import * as enzyme from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import * as Adapter from 'enzyme-adapter-react-16'
 
 enzyme.configure({ adapter: new Adapter() })


### PR DESCRIPTION
This is just to remove obstacles for the all happy TypeScript library consumers. 