### PR TITLE
Move react to peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ React Adopt is a simple method that composes multiple render prop components, co
 Install as project dependency:
 
 ```bash
-$ yarn add react-adopt
+$ yarn add react-adopt react
 ```
 
 Now you can use React Adopt to compose your components. See below for an example using the awesome [react-powerplug](https://github.com/renatorib/react-powerplug):

--- a/package.json
+++ b/package.json
@@ -35,11 +35,10 @@
   ],
   "dependencies": {
     "hoist-non-react-statics": "^2.5.0",
-    "react": "^16.3.2",
     "react-display-name": "^0.2.4"
   },
   "peerDependencies": {
-    "react": ">= 0.14.0"
+    "react": "^16.3.2"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,15 +4331,6 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.0"
     react-is "^16.3.0"
 
-react@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.npmjs.org/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"


### PR DESCRIPTION
Including react as a dependency causes this module to break on certain environments when using react hooks. This is because yarn/npm will resolve react-adopt's version of react _and_ any local react dependencies and include them _both_. This will happen in some Jest testing environments, as well.

This PR moves react to a peer dependency to avoid multiple versions of react existing in the same application/environment.